### PR TITLE
Use `prop-types` package.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "autobind-decorator": "^1.3.4",
     "prop-types": "15.6.2",
     "ramda": "^0.23.0",
-    "react-drag-sort": "git://github.com/zgrannan/react-drag-sort.git#ccc5433172a4742fe9c20e383d9652220c19144b"
+    "react-drag-sort": "^2.1.1"
   },
   "peerDependencies": {
     "react": ""

--- a/package.json
+++ b/package.json
@@ -17,8 +17,9 @@
   },
   "dependencies": {
     "autobind-decorator": "^1.3.4",
+    "prop-types": "15.6.2",
     "ramda": "^0.23.0",
-    "react-drag-sort": "^2.1.0"
+    "react-drag-sort": "git://github.com/zgrannan/react-drag-sort.git#ccc5433172a4742fe9c20e383d9652220c19144b"
   },
   "peerDependencies": {
     "react": ""

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "autobind-decorator": "^1.3.4",
-    "prop-types": "15.6.2",
+    "prop-types": "^15.6.2",
     "ramda": "^0.23.0",
     "react-drag-sort": "^2.1.1"
   },

--- a/src/ListInput.js
+++ b/src/ListInput.js
@@ -1,6 +1,7 @@
 import R from 'ramda'
 import autobind from 'autobind-decorator'
-import React, { PropTypes } from 'react'
+import PropTypes from 'prop-types'
+import React from 'react'
 import { debounce } from 'lodash'
 
 import genKey from './genKey'

--- a/yarn.lock
+++ b/yarn.lock
@@ -4299,7 +4299,7 @@ promise@7.1.1, promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@15.6.2, prop-types@^15.6.2:
+prop-types@^15.6.2:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2997,6 +2997,10 @@ js-tokens@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.1.tgz#08e9f132484a2c45a30907e9dc4d5567b7f114d7"
 
+"js-tokens@^3.0.0 || ^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
+
 js-yaml@3.x, js-yaml@^3.4.3, js-yaml@~3.7.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.7.0.tgz#5c967ddd837a9bfdca5f2de84253abe8a1c03b80"
@@ -3297,6 +3301,12 @@ loose-envify@^1.0.0, loose-envify@^1.1.0:
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
     js-tokens "^3.0.0"
+
+loose-envify@^1.3.1:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
+  dependencies:
+    js-tokens "^3.0.0 || ^4.0.0"
 
 loud-rejection@^1.0.0:
   version "1.6.0"
@@ -3734,7 +3744,7 @@ object-assign@4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.0.tgz#7a3b3d0e98063d43f4c03f2e8ae6cd51a86883a0"
 
-object-assign@4.1.1, object-assign@^4.0.1, object-assign@^4.1.0:
+object-assign@4.1.1, object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
@@ -4289,6 +4299,13 @@ promise@7.1.1, promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
+prop-types@15.6.2, prop-types@^15.6.2:
+  version "15.6.2"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
+  dependencies:
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
+
 proxy-addr@~1.1.2:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-1.1.3.tgz#dc97502f5722e888467b3fa2297a7b1ff47df074"
@@ -4431,11 +4448,12 @@ react-dom@^15.4.2:
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
 
-react-drag-sort@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/react-drag-sort/-/react-drag-sort-2.1.0.tgz#b15c94f89921d4fae590a8267985a856107b1099"
+"react-drag-sort@git://github.com/zgrannan/react-drag-sort.git#ccc5433172a4742fe9c20e383d9652220c19144b":
+  version "2.1.1"
+  resolved "git://github.com/zgrannan/react-drag-sort.git#ccc5433172a4742fe9c20e383d9652220c19144b"
   dependencies:
     autobind-decorator "^1.3.4"
+    prop-types "^15.6.2"
     ramda "^0.23.0"
     react-dnd "^2.1.4"
     react-dnd-html5-backend "^2.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4448,9 +4448,9 @@ react-dom@^15.4.2:
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
 
-"react-drag-sort@git://github.com/zgrannan/react-drag-sort.git#ccc5433172a4742fe9c20e383d9652220c19144b":
-  version "2.1.1"
-  resolved "git://github.com/zgrannan/react-drag-sort.git#ccc5433172a4742fe9c20e383d9652220c19144b"
+react-drag-sort@^2.1.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/react-drag-sort/-/react-drag-sort-2.2.1.tgz#c1b59c8680a614278489cac6785d4086dba9afbb"
   dependencies:
     autobind-decorator "^1.3.4"
     prop-types "^15.6.2"


### PR DESCRIPTION
Uses the `prop-types` package and upgrades `react-drag-sort` to version `2.1.1`.

This should enable compatibility with React 16.